### PR TITLE
fix(action): consider `Item.data.col` as a 1-based

### DIFF
--- a/lua/deck/builtin/action/init.lua
+++ b/lua/deck/builtin/action/init.lua
@@ -71,7 +71,7 @@ do
             vim.cmd.edit(filename_or_bufnr)
           end
           if item.data.lnum then
-            vim.api.nvim_win_set_cursor(0, { item.data.lnum, item.data.col or 0 })
+            vim.api.nvim_win_set_cursor(0, { item.data.lnum, (item.data.col or 1) - 1 })
           end
         end
 


### PR DESCRIPTION
`Item.data.col` is already used as a 1-based in previewers, so this PR fixes actions instead of sources.