### PR TITLE
fix(view): set `flush` option for `nvim__redraw()`

### DIFF
--- a/lua/deck/builtin/view/default.lua
+++ b/lua/deck/builtin/view/default.lua
@@ -140,6 +140,7 @@ function default_view.create(config)
     -- redraw if cmdline.
     if vim.fn.mode(1):sub(1, 1) == 'c' then
       vim.api.nvim__redraw({
+        flush = true,
         valid = true,
         win = state.win,
       })


### PR DESCRIPTION
I can't filter interactively without `flush` option in my environment.

```lua
-- deck.lua
require('deck.easy').setup()

vim.api.nvim_create_autocmd('User', {
  pattern = 'DeckStart',
  callback = function(e)
    e.data.ctx.prompt()
  end,
})
```

```console
$ uname -om
x86_64 GNU/Linux

$ nvim -v
NVIM v0.10.4
Build type: RelWithDebInfo
LuaJIT 2.1.1731601260
Run "nvim -V1 -v" for more info

$ nvim --clean --cmd "set rtp^=path/to/nvim-deck" -c "luafile deck.lua"
```