### PR TITLE
fix: use `Context.set_cursor` to move cursor in `toggle_select` action

### DIFF
--- a/lua/deck/builtin/action/init.lua
+++ b/lua/deck/builtin/action/init.lua
@@ -322,7 +322,7 @@ action.toggle_select = {
     local cursor_item = ctx.get_cursor_item()
     if cursor_item then
       ctx.set_selected(cursor_item, not ctx.get_selected(cursor_item))
-      vim.cmd.normal('j')
+      ctx.set_cursor(ctx.get_cursor() + 1)
     end
   end,
 }


### PR DESCRIPTION
This PR fixes an issue where `toggle_select` action doesn't change the internal cursor state.