### PR TITLE
refactor: always set `ephemeral` option for decorations

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,6 @@ require('deck').register_decorator({
           end_row = row,
           end_col = e + 1,
           conceal = '',
-          ephemeral = true,
         },
         -- Display the directory name as a comment at the end of the line
         {

--- a/lua/deck/Context.lua
+++ b/lua/deck/Context.lua
@@ -184,7 +184,7 @@ function Context.create(id, source, start_config)
         virt_text_repeat_linebreak = decoration.virt_text_repeat_linebreak,
         virt_lines = decoration.virt_lines,
         virt_lines_above = decoration.virt_lines_above,
-        ephemeral = decoration.ephemeral,
+        ephemeral = true,
         priority = decoration.priority,
         sign_text = decoration.sign_text,
         sign_hl_group = decoration.sign_hl_group,
@@ -199,7 +199,6 @@ function Context.create(id, source, start_config)
         if bufnr ~= context.buf then
           return
         end
-        vim.api.nvim_buf_clear_namespace(context.buf, context.ns, toprow, botrow + 1)
 
         for row = toprow, botrow do
           local item = buffer:get_rendered_items()[row + 1]

--- a/lua/deck/builtin/decorator/init.lua
+++ b/lua/deck/builtin/decorator/init.lua
@@ -49,7 +49,6 @@ decorators.highlights = {
           col = hi[1],
           end_col = hi[2],
           hl_group = hi.hl_group,
-          ephemeral = true,
         })
       end
     end
@@ -92,7 +91,6 @@ decorators.query_matches = {
         col = match[1],
         end_col = match[2],
         hl_group = 'Search',
-        ephemeral = true,
       })
     end
     return decorations
@@ -128,7 +126,6 @@ do
           virt_text = { { modified and '[+]' or '', 'SpecialKey' }, { ' ' }, { ('#%s'):format(buf), 'Comment' }, },
           virt_text_pos = 'eol',
           hl_mode = 'combine',
-          ephemeral = true,
         })
       end
 

--- a/lua/deck/init.lua
+++ b/lua/deck/init.lua
@@ -32,7 +32,6 @@ local ExecuteContext = require('deck.ExecuteContext')
 ---@field public virt_text_repeat_linebreak? boolean
 ---@field public virt_lines? deck.VirtualText[][]
 ---@field public virt_lines_above? boolean
----@field public ephemeral? boolean
 ---@field public priority? integer
 ---@field public sign_text? string
 ---@field public sign_hl_group? string


### PR DESCRIPTION
We can use `ephemeral` option instead of calling `nvim_buf_clear_namespace()`.