### PR TITLE
fix(explorer)!: replace `auto_resize` feature with `drawer_picker`

### DIFF
--- a/lua/deck/builtin/view/drawer_picker.lua
+++ b/lua/deck/builtin/view/drawer_picker.lua
@@ -12,11 +12,16 @@ return function(config)
       ---@param ctx deck.Context
       ---@param view deck.View
       kit.fast_schedule_wrap(function(ctx, view)
-        local max_line_width = 0
-        for _, text in ipairs(vim.api.nvim_buf_get_lines(ctx.buf, 0, -1, false)) do
-          max_line_width = math.max(max_line_width, vim.fn.strdisplaywidth(text))
+        local next_width
+        if vim.api.nvim_get_current_buf() == ctx.buf then
+          local max_line_width = 0
+          for _, text in ipairs(vim.api.nvim_buf_get_lines(ctx.buf, 0, -1, false)) do
+            max_line_width = math.max(max_line_width, vim.fn.strdisplaywidth(text))
+          end
+          next_width = math.max(max_line_width + 3, min_width)
+        else
+          next_width = min_width
         end
-        local next_width = math.max(max_line_width + 3, min_width)
         if next_width ~= width then
           width = next_width
           if view.is_visible(ctx) then
@@ -26,7 +31,13 @@ return function(config)
       end),
       100
     )
+    local bufenter
     function calc_width(ctx, view)
+      bufenter = bufenter or vim.api.nvim_create_autocmd('BufEnter', {
+        callback = function()
+          update_width(ctx, view)
+        end,
+      })
       update_width(ctx, view)
       return width
     end

--- a/lua/deck/builtin/view/drawer_picker.lua
+++ b/lua/deck/builtin/view/drawer_picker.lua
@@ -24,7 +24,7 @@ return function(config)
           end
         end
       end),
-      200
+      100
     )
     function calc_width(ctx, view)
       update_width(ctx, view)

--- a/lua/deck/easy.lua
+++ b/lua/deck/easy.lua
@@ -1,4 +1,3 @@
-local x = require('deck.x')
 local kit = require('deck.kit')
 local augroup = vim.api.nvim_create_augroup('deck.easy', { clear = true })
 
@@ -86,19 +85,10 @@ function easy.setup(config)
           reveal = args['--reveal'] or config.get_buffer_path(vim.api.nvim_get_current_buf()),
         }
 
-        x.ensure_win('deck.easy.explorer', function()
-          vim.cmd(('noautocmd keepalt keepjumps %s %s%s +%sbuffer'):format('topleft', option.width, 'vsplit', vim.api.nvim_create_buf(false, true)))
-          return vim.api.nvim_get_current_win()
-        end, function(win)
-          vim.api.nvim_set_current_win(win)
-          vim.api.nvim_set_option_value('winfixwidth', true, { win = win })
-        end)
-
         deck.start({
           require('deck.builtin.source.explorer')({
             cwd = option.cwd,
             mode = 'drawer',
-            min_width = option.width,
             reveal = option.reveal or option.cwd,
             narrow = {
               enable = true,
@@ -107,7 +97,7 @@ function easy.setup(config)
           }),
         }, {
           view = function()
-            return require('deck.builtin.view.current_picker')()
+            return require('deck.builtin.view.drawer_picker')({ auto_resize = true, min_width = option.width })
           end,
           dedup = false,
           history = false,


### PR DESCRIPTION
Current `auto_resize` implementation cannot redraw correctly, so this PR replaces it with `drawer_picker` and removes related options from `explorer` source.