### PR TITLE
refactor(matcher): allow returning float as score instead of integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,7 +1335,7 @@ Start deck with given sources.
 ---@field public display_text string|(deck.VirtualText[])
 ---@field public highlights? deck.Highlight[]
 ---@field public filter_text? string
----@field public score_bonus? integer
+---@field public score_bonus? number
 ---@field public dedup_id? string
 ---@field public data? table
 ```

--- a/doc/deck.txt
+++ b/doc/deck.txt
@@ -1221,7 +1221,7 @@ Start deck with given sources.
     ---@field public display_text string|(deck.VirtualText[])
     ---@field public highlights? deck.Highlight[]
     ---@field public filter_text? string
-    ---@field public score_bonus? integer
+    ---@field public score_bonus? number
     ---@field public dedup_id? string
     ---@field public data? table
 <

--- a/lua/deck/TopK.lua
+++ b/lua/deck/TopK.lua
@@ -1,7 +1,7 @@
 ---@class deck.TopK
 ---@field _size integer
----@field _entries { item: deck.Item, score: integer }[]
----@field _min_score integer
+---@field _entries { item: deck.Item, score: number }[]
+---@field _min_score number
 local TopK = {}
 TopK.__index = TopK
 
@@ -18,7 +18,7 @@ end
 
 ---Try to add an item with a score to the TopK.
 ---@param item deck.Item
----@param score integer
+---@param score number
 ---@return deck.Item?
 function TopK:add(item, score)
   local entries = self._entries

--- a/lua/deck/builtin/matcher/default.lua
+++ b/lua/deck/builtin/matcher/default.lua
@@ -34,7 +34,7 @@ end
 ---@param text string
 ---@param semantic_indexes integer[]
 ---@param with_ranges boolean
----@return integer, { [1]: integer, [2]: integer }[]?
+---@return number, { [1]: integer, [2]: integer }[]?
 local function compute(
     query,
     text,
@@ -322,7 +322,7 @@ local default = {}
 ---Match query against text and return a score.
 ---@param input string
 ---@param text string
----@return integer
+---@return number
 function default.match(input, text)
   local fuzzies, filters = parse_query(input)
   if #fuzzies == 0 and #filters == 0 then

--- a/lua/deck/init.lua
+++ b/lua/deck/init.lua
@@ -40,7 +40,7 @@ local Context = require('deck.Context')
 ---@field public conceal? string
 
 ---@doc.type
----@alias deck.Matcher.MatchFunction fun(query: string, text: string): integer
+---@alias deck.Matcher.MatchFunction fun(query: string, text: string): number
 ---@alias deck.Matcher.DecorFunction fun(query: string, text: string): deck.Highlight[]
 ---@alias deck.Matcher { match: deck.Matcher.MatchFunction, decor?: deck.Matcher.DecorFunction }
 
@@ -49,7 +49,7 @@ local Context = require('deck.Context')
 ---@field public display_text string|(deck.VirtualText[])
 ---@field public highlights? deck.Highlight[]
 ---@field public filter_text? string
----@field public score_bonus? integer
+---@field public score_bonus? number
 ---@field public dedup_id? string
 ---@field public data? table
 


### PR DESCRIPTION
This PR just replaces some `integer` type annotations with `number`.